### PR TITLE
Fixed a bug with Schema interactors later in the chain

### DIFF
--- a/lib/interactor/schema/context.rb
+++ b/lib/interactor/schema/context.rb
@@ -18,7 +18,7 @@ module Interactor
       end
 
       def assign(context)
-        filtered_context = context.select { |k, _| _schema.include?(k) }
+        filtered_context = context.to_h.select { |k, _| _schema.include?(k) }
         @table.merge!(filtered_context)
       end
 

--- a/lib/interactor/schema/version.rb
+++ b/lib/interactor/schema/version.rb
@@ -1,5 +1,5 @@
 module Interactor
   module Schema
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end


### PR DESCRIPTION
What happened:
When an interactor chain starts without a schema, but is assigned one later, it will call Schema::Context.build instead of Context.build

`OpenStruct`s respond to all missing methods with `nil` by default. In this case, `select` is not a method on an `OpenStruct`.

By calling `to_h` on an OpenStruct we are able to select the attributes that are included in the schema